### PR TITLE
Fix guzzle 6 compatibility issue

### DIFF
--- a/src/Api/AppleApiClient.php
+++ b/src/Api/AppleApiClient.php
@@ -5,7 +5,6 @@ namespace Azimo\Apple\Api;
 use Azimo\Apple\Api\Exception\PublicKeyFetchingFailedException;
 use Azimo\Apple\Api\Factory\ResponseFactory;
 use GuzzleHttp;
-use GuzzleHttp\Utils;
 use InvalidArgumentException;
 
 final class AppleApiClient implements AppleApiClientInterface

--- a/src/Api/Utils.php
+++ b/src/Api/Utils.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Azimo\Apple\Api;
+
+use InvalidArgumentException;
+
+final class Utils
+{
+    /**
+     * Wrapper for json_decode that throws when an error occurs.
+     *
+     * @param string $json    JSON data to parse
+     * @param bool   $assoc   When true, returned objects will be converted
+     *                        into associative arrays.
+     * @param int    $depth   User specified recursion depth.
+     * @param int    $options Bitmask of JSON decode options.
+     *
+     * @return object|array|string|int|float|bool|null
+     *
+     * @throws InvalidArgumentException if the JSON cannot be decoded.
+     *
+     * @link https://www.php.net/manual/en/function.json-decode.php
+     */
+    public static function jsonDecode(string $json, bool $assoc = false, int $depth = 512, int $options = 0)
+    {
+        $data = \json_decode($json, $assoc, $depth, $options);
+        if (\JSON_ERROR_NONE !== \json_last_error()) {
+            throw new InvalidArgumentException('json_decode error: ' . \json_last_error_msg());
+        }
+
+        return $data;
+    }
+}

--- a/tests/Unit/Api/UtilsTest.php
+++ b/tests/Unit/Api/UtilsTest.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Azimo\Apple\Tests\Unit\Api;
+
+use Azimo\Apple\Api\Utils;
+use PHPUnit\Framework\TestCase;
+use InvalidArgumentException;
+
+final class UtilsTest extends TestCase
+{
+    public function testDecodesJson()
+    {
+        $this->assertTrue(Utils::jsonDecode('true'));
+        $this->assertEquals(['a' => 1, 'b' => 2], Utils::jsonDecode('{"a":1,"b":2}', true));
+        $this->assertEquals((object) ['a' => 1, 'b' => 2], Utils::jsonDecode('{"a":1,"b":2}'));
+        $this->assertEquals([5, 10], Utils::jsonDecode('[5, 10]', true));
+        $this->assertEquals([5, 10], Utils::jsonDecode('[5, 10]'));
+    }
+
+    public function testDecodesJsonAndThrowsOnError()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        Utils::jsonDecode('{{]]');
+    }
+}


### PR DESCRIPTION
Fix `Call to undefined method GuzzleHttp\Utils::jsonDecode()` error when guzzle 6 dependency is installed.